### PR TITLE
Fix: sign transactions

### DIFF
--- a/src/hooks/transactions/useSignTransactions.tsx
+++ b/src/hooks/transactions/useSignTransactions.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import { ExtensionProvider, Nonce, Transaction } from '@elrondnetwork/erdjs';
 
 import { errorsMessages, walletSignSession } from 'constants/index';
@@ -29,7 +29,7 @@ export const useSignTransactions = () => {
   const [error, setError] = useState<string | null>(null);
   const transactionsToSign = useSelector(transactionsToSignSelector);
   const hasTransactions = Boolean(transactionsToSign?.transactions);
-
+  const prevSessionIdRef = useRef<string>();
   useParseSignedTransactions();
 
   const onAbort = (sessionId?: string) => {
@@ -216,9 +216,17 @@ export const useSignTransactions = () => {
     }
   };
 
+  const sessionId = useMemo(() => transactionsToSign?.sessionId, [
+    transactionsToSign
+  ]);
+
   useEffect(() => {
+    if (prevSessionIdRef.current && sessionId) {
+      onAbort();
+    }
+    prevSessionIdRef.current = sessionId;
     signTransactions();
-  }, [transactionsToSign]);
+  }, [sessionId]);
 
   return {
     error,

--- a/src/hooks/transactions/useSignTransactions.tsx
+++ b/src/hooks/transactions/useSignTransactions.tsx
@@ -222,7 +222,7 @@ export const useSignTransactions = () => {
 
   useEffect(() => {
     if (prevSessionIdRef.current && sessionId) {
-      onAbort();
+      onAbort(prevSessionIdRef.current);
     }
     prevSessionIdRef.current = sessionId;
     signTransactions();


### PR DESCRIPTION
**Error**: request for signing a single transaction multiple times cause Maiar extension to open multiple signing windows, after each request nonce from the store gets increased -> after confirming the last transaction the redux store a wrong nonce which leads to the nonce gap problem -> user must correct nonce in `localStorage` or restart and reconnect wallet.
**Solution**: 
- request for signing transaction every time `sessionId` changed, not the reference to the `transactionToSign`
- cancel the previous transaction if it has not been signed yet to terminate the signing flow for it and create a new signing request for the current transaction.